### PR TITLE
Handle new and old sources. Init empty properties.

### DIFF
--- a/lib/mapdataLoader.js
+++ b/lib/mapdataLoader.js
@@ -74,6 +74,9 @@ function expandArraysAndCollections(mapdata, geojson) {
                 expandArraysAndCollections(mapdata, geojson.features);
                 break;
             case 'Feature':
+                // init empty "properties" so it doesn't fail with
+                // "invalid json" in geojson-mapnikify
+                geojson.properties = geojson.properties || {};
                 mapdata.push(geojson);
                 break;
             default:

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -57,14 +57,21 @@ function makeParams(params, tileSource) {
         },
         format: params.format,
         getTile: function(z, x, y, cb) {
-            const opts = {
-                type: 'tile',
-                z: z,
-                x: x,
-                y: y,
-                lang: params.lang
-            };
-            return tileSource.getAsync(opts).then(data => cb(undefined, data.data, data.headers))
+            if ( typeof tileSource.getAsync === 'function' ) {
+                const opts = {
+                    type: 'tile',
+                    z: z,
+                    x: x,
+                    y: y,
+                    lang: params.lang
+                };
+                return tileSource.getAsync(opts).then(
+                    data => cb(undefined, data.data, data.headers)
+                ).catch(err => cb(err));
+            } else {
+                // source is old school and can't receive lang param
+                return tileSource.getTile(z, x, y, cb);
+            }
         }
     };
 }


### PR DESCRIPTION
- Handle sources that don't implement getAsync
- Shim geojson feature "properties" so that default properties can be added (https://github.com/mapbox/geojson-mapnikify/blob/v0.7.2/lib/defaults.js#L35) so it doesn't fail on https://github.com/mapbox/geojson-mapnikify/blob/v0.7.2/index.js#L66