### PR TITLE
abaculus -> @mapbox/abaculus

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -3,7 +3,7 @@
 let util = require('util'),
     Err = require('@kartotherian/err'),
     Promise = require('bluebird'),
-    abaculus = Promise.promisify(require('abaculus'), {multiArgs: true}),
+    abaculus = Promise.promisify(require('@mapbox/abaculus'), {multiArgs: true}),
     Overlay = require('tilelive-overlay'),
     _ = require('underscore'),
     checkType = require('@kartotherian/input-validator'),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/kartotherian/snapshot",
   "dependencies": {
-    "abaculus": "^2.0.3",
+    "@mapbox/abaculus": "^2.0.3",
     "bluebird": "^3.5.0",
     "domain-validator": "^0.0.5",
     "geojson-mapnikify": "^0.7.2",


### PR DESCRIPTION
Gets rid of a direct, and a few transitive, deprecation warnings.