### PR TITLE
Get exact version of tilelive-overlay to avoid pulling mapnik 4.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@mapbox/geojson-mapnikify": "^1.1.0",
     "leaflet-headless": "^0.2.5",
     "mwapi": "^0.0.10",
-    "@mapbox/tilelive-overlay": "^1.0.0",
+    "@mapbox/tilelive-overlay": "1.0.0",
     "underscore": "^1.8.3",
     "@kartotherian/err": "^0.0.3",
     "@kartotherian/input-validator": "^0.0.6",


### PR DESCRIPTION
Snapshot is pulling tilelive-overlay 1.1.0 which depends on node-mapnik 4.0.x.

It is blocking: https://github.com/kartotherian/kartotherian/pull/80