### PR TITLE
Fix var initialization in lib/autoPosition.js

### DIFF
--- a/lib/autoPosition.js
+++ b/lib/autoPosition.js
@@ -1,7 +1,7 @@
 'use strict';
 
-let L = require( 'leaflet-headless' ),
-    worldLatLng = new L.LatLngBounds( [ -90, -180 ], [ 90, 180 ] ),
+const L = require( 'leaflet-headless' );
+const worldLatLng = new L.LatLngBounds( [ -90, -180 ], [ 90, 180 ] );
 
 /* eslint-disable no-underscore-dangle */
 /**


### PR DESCRIPTION
A recent change removed the semicolon from the end of the list of
variables initialized at the beginning of the file, introducing a runtime
error.

This change fixes the issue by initializing one variable at a time (in
lines ending in semicolons).  const is used instead of let as it's more
appropriate (these values don't change).